### PR TITLE
feat: [GCP Batch] Support passing standard machine types to the Google backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@ be found [here](https://cromwell.readthedocs.io/en/stable/backends/HPC/#optional
 ### GCP Batch
 
 - The `genomics` configuration entry was renamed to `batch`, see [ReadTheDocs](https://cromwell.readthedocs.io/en/stable/backends/GCPBatch/) for more information.
+- Fixes a bug with not being able to recover jobs on Cromwell restart.
+- Fixes machine type selection to match the Google Cloud Life Sciences backend, including default n1 non shared-core machine types and correct handling of `cpuPlatform` to select n2 or n2d machine types as appropriate.
 - Fixes the preemption error handling, now, the correct error message is printed, this also handles the other potential exit codes.
 - Fixes pulling Docker image metadata from private GCR repositories.
 - Fixed `google_project` and `google_compute_service_account` workflow options not taking effect when using GCP Batch backend

--- a/build.sbt
+++ b/build.sbt
@@ -237,6 +237,7 @@ lazy val googlePipelinesV2Beta = (project in backendRoot / "google" / "pipelines
 
 lazy val googleBatch = (project in backendRoot / "google" / "batch")
   .withLibrarySettings("cromwell-google-batch-backend")
+  .dependsOn(core)
   .dependsOn(backend)
   .dependsOn(gcsFileSystem)
   .dependsOn(drsFileSystem)

--- a/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
+++ b/centaur/src/main/resources/standardTestCases/papi_cpu_platform.test
@@ -1,6 +1,7 @@
 name: papi_cpu_platform
 testFormat: workflowsuccess
-backends: [Papiv2]
+backendsMode: any
+backends: [Papiv2, GCPBATCH]
 
 files {
   workflow: papi_cpu_platform/papi_cpu_platform.wdl

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/BatchApiRunCreationClient.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/actors/BatchApiRunCreationClient.scala
@@ -53,7 +53,7 @@ trait BatchApiRunCreationClient { this: Actor with ActorLogging with BatchInstru
         backendSingletonActor ! BatchApiRequestManager.BatchRunCreationRequest(
           request.workflowId,
           self,
-          requestFactory.submitRequest(request)
+          requestFactory.submitRequest(request, jobLogger)
         )
         val newPromise = Promise[StandardAsyncJob]()
         runCreationClientPromise = Option(newPromise)

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactory.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactory.scala
@@ -6,13 +6,14 @@ import cromwell.backend.google.batch.io.GcpBatchAttachedDisk
 import cromwell.backend.google.batch.models.GcpBatchConfigurationAttributes.VirtualPrivateCloudConfiguration
 import cromwell.backend.google.batch.models._
 import cromwell.backend.google.batch.monitoring.{CheckpointingConfiguration, MonitoringImage}
+import cromwell.core.logging.JobLogger
 import cromwell.core.path.Path
 import wom.runtime.WomOutputRuntimeExtractor
 
 import scala.concurrent.duration.FiniteDuration
 
 trait GcpBatchRequestFactory {
-  def submitRequest(data: GcpBatchRequest): CreateJobRequest
+  def submitRequest(data: GcpBatchRequest, jobLogger: JobLogger): CreateJobRequest
 
   def queryRequest(jobName: JobName): GetJobRequest
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -230,6 +230,7 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
     val machineType = GcpBatchMachineConstraints.machineType(runtimeAttributes.memory,
                                                              runtimeAttributes.cpu,
                                                              cpuPlatformOption = runtimeAttributes.cpuPlatform,
+                                                             standardMachineTypeOption = runtimeAttributes.standardMachineType,
                                                              googleLegacyMachineSelection = false,
                                                              jobLogger = jobLogger
     )

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchCustomMachineType.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchCustomMachineType.scala
@@ -11,6 +11,8 @@ import wom.format.MemorySize
 
 import scala.math.{log, pow}
 
+case class StandardMachineType(machineType: String) {}
+
 /**
   * Adjusts memory and cpu for custom machine types.
   *

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
@@ -49,7 +49,8 @@ final case class GcpBatchRuntimeAttributes(cpu: Int Refined Positive,
                                            continueOnReturnCode: ContinueOnReturnCode,
                                            noAddress: Boolean,
                                            useDockerImageCache: Option[Boolean],
-                                           checkpointFilename: Option[String]
+                                           checkpointFilename: Option[String],
+                                           standardMachineType: Option[String]
 )
 
 object GcpBatchRuntimeAttributes {
@@ -85,6 +86,8 @@ object GcpBatchRuntimeAttributes {
     UseDockerImageCacheKey
   ).optional
 
+  val StandardMachineTypeKey = "standardMachineType"
+
   val CheckpointFileKey = "checkpointFile"
   private val checkpointFileValidationInstance = new StringRuntimeAttributesValidation(CheckpointFileKey).optional
 
@@ -98,6 +101,8 @@ object GcpBatchRuntimeAttributes {
       )
   private def cpuPlatformValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[String] =
     cpuPlatformValidationInstance
+  private def standardMachineTypeValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[String] =
+    new StringRuntimeAttributesValidation(StandardMachineTypeKey).optional
   private def gpuTypeValidation(runtimeConfig: Option[Config]): OptionalRuntimeAttributesValidation[GpuType] =
     GpuTypeValidation.optional
 
@@ -171,7 +176,8 @@ object GcpBatchRuntimeAttributes {
         bootDiskSizeValidation(runtimeConfig),
         useDockerImageCacheValidation(runtimeConfig),
         checkpointFileValidationInstance,
-        dockerValidation
+        dockerValidation,
+        standardMachineTypeValidation(runtimeConfig)
       )
   }
 
@@ -228,6 +234,10 @@ object GcpBatchRuntimeAttributes {
       useDockerImageCacheValidation(runtimeAttrsConfig).key,
       validatedRuntimeAttributes
     )
+    val standardMachineType: Option[String] = RuntimeAttributesValidation.extractOption(
+      standardMachineTypeValidation(runtimeAttrsConfig).key,
+      validatedRuntimeAttributes
+    )
 
     new GcpBatchRuntimeAttributes(
       cpu = cpu,
@@ -243,7 +253,8 @@ object GcpBatchRuntimeAttributes {
       continueOnReturnCode = continueOnReturnCode,
       noAddress = noAddress,
       useDockerImageCache = useDockerImageCache,
-      checkpointFilename = checkpointFileName
+      checkpointFilename = checkpointFileName,
+      standardMachineType = standardMachineType
     )
   }
 

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributes.scala
@@ -77,6 +77,7 @@ object GcpBatchRuntimeAttributes {
   private val cpuPlatformValidationInstance = new StringRuntimeAttributesValidation(CpuPlatformKey).optional
   // via `gcloud compute zones describe us-central1-a`
   val CpuPlatformIntelCascadeLakeValue = "Intel Cascade Lake"
+  val CpuPlatformIntelIceLakeValue = "Intel Ice Lake"
   val CpuPlatformAMDRomeValue = "AMD Rome"
 
   val UseDockerImageCacheKey = "useDockerImageCache"

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
@@ -6,9 +6,9 @@ import cromwell.backend.google.batch.models.{
   N2CustomMachineType,
   N2DCustomMachineType
 }
+import cromwell.core.logging.JobLogger
 import eu.timepit.refined.api.Refined
 import eu.timepit.refined.numeric.Positive
-import org.slf4j.Logger
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 
@@ -17,16 +17,17 @@ object GcpBatchMachineConstraints {
                   cpu: Int Refined Positive,
                   cpuPlatformOption: Option[String],
                   googleLegacyMachineSelection: Boolean,
-                  jobLogger: Logger
+                  jobLogger: JobLogger
   ): String =
     if (googleLegacyMachineSelection) {
       s"predefined-$cpu-${memory.to(MemoryUnit.MB).amount.intValue()}"
     } else {
-      // If someone requests Intel Cascade Lake as their CPU platform then switch the machine type to n2.
+      // If someone requests Intel Cascade Lake or Intel Ice Lake as their CPU platform then switch the machine type to n2.
       // Similarly, CPU platform of AMD Rome corresponds to the machine type n2d.
       val customMachineType =
         cpuPlatformOption match {
           case Some(GcpBatchRuntimeAttributes.CpuPlatformIntelCascadeLakeValue) => N2CustomMachineType
+          case Some(GcpBatchRuntimeAttributes.CpuPlatformIntelIceLakeValue) => N2CustomMachineType
           case Some(GcpBatchRuntimeAttributes.CpuPlatformAMDRomeValue) => N2DCustomMachineType
           case _ => N1CustomMachineType
         }

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraints.scala
@@ -4,7 +4,8 @@ import cromwell.backend.google.batch.models.{
   GcpBatchRuntimeAttributes,
   N1CustomMachineType,
   N2CustomMachineType,
-  N2DCustomMachineType
+  N2DCustomMachineType,
+  StandardMachineType
 }
 import cromwell.core.logging.JobLogger
 import eu.timepit.refined.api.Refined
@@ -16,10 +17,13 @@ object GcpBatchMachineConstraints {
   def machineType(memory: MemorySize,
                   cpu: Int Refined Positive,
                   cpuPlatformOption: Option[String],
+                  standardMachineTypeOption: Option[String],
                   googleLegacyMachineSelection: Boolean,
                   jobLogger: JobLogger
   ): String =
-    if (googleLegacyMachineSelection) {
+    if (standardMachineTypeOption.exists(_.trim.nonEmpty)) {
+      StandardMachineType(standardMachineTypeOption.get).machineType
+    } else if (googleLegacyMachineSelection) {
       s"predefined-$cpu-${memory.to(MemoryUnit.MB).amount.intValue()}"
     } else {
       // If someone requests Intel Cascade Lake or Intel Ice Lake as their CPU platform then switch the machine type to n2.

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/actors/GcpBatchAsyncBackendJobExecutionActorSpec.scala
@@ -131,7 +131,7 @@ class GcpBatchAsyncBackendJobExecutionActorSpec
     val runtimeAttributesBuilder = GcpBatchRuntimeAttributes.runtimeAttributesBuilder(configuration)
 
     val requestFactory: GcpBatchRequestFactory = new GcpBatchRequestFactory {
-      override def submitRequest(data: GcpBatchRequest): CreateJobRequest = null
+      override def submitRequest(data: GcpBatchRequest, jobLogger: JobLogger): CreateJobRequest = null
 
       override def queryRequest(jobName: JobName): GetJobRequest = null
 

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributesSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/models/GcpBatchRuntimeAttributesSpec.scala
@@ -286,7 +286,8 @@ trait GcpBatchRuntimeAttributesSpecsMixin {
     continueOnReturnCode = ContinueOnReturnCodeSet(Set(0)),
     noAddress = false,
     useDockerImageCache = None,
-    checkpointFilename = None
+    checkpointFilename = None,
+    standardMachineType = None
   )
 
   def assertBatchRuntimeAttributesSuccessfulCreation(runtimeAttributes: Map[String, WomValue],

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
@@ -24,77 +24,104 @@ class GcpBatchMachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpe
 
   it should "generate valid machine types" in {
     val validTypes = Table(
-      ("memory", "cpu", "cpuPlatformOption", "googleLegacyMachineSelection", "machineTypeString"),
+      ("memory", "cpu", "cpuPlatformOption", "standardMachineTypeOption", "googleLegacyMachineSelection", "machineTypeString"),
       // Already ok tuple
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, false, "custom-1-1024"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, None, false, "custom-1-1024"),
       // CPU must be even (except if it's 1)
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, false, "custom-4-4096"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, None, false, "custom-4-4096"),
       // Memory must be a multiple of 256
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, false, "custom-1-1024"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, None, false, "custom-1-1024"),
       // Memory / cpu ratio must be > 0.9GB, increase memory
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, false, "custom-4-3840"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, false, "custom-16-14848"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, None, false, "custom-4-3840"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, None, false, "custom-16-14848"),
       // Memory / cpu ratio must be < 6.5GB, increase CPU
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, false, "custom-4-14080"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, None, false, "custom-4-14080"),
       // Memory should be an int
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, false, "custom-1-1536"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, false, "custom-1-1024"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, None, false, "custom-1-1536"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, None, false, "custom-1-1024"),
       // Increase to a cpu selection not valid for n2 below
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, false, "custom-34-31488"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, None, false, "custom-34-31488"),
 
       // Same tests as above but with legacy machine type selection (cpu and memory as specified. No 'custom machine
       // requirement' adjustments are expected this time, except float->int)
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1024"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, true, "predefined-3-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, true, "predefined-1-1024"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, true, "predefined-4-1024"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, true, "predefined-16-14336"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, true, "predefined-1-13977"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1520"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1024"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, true, "predefined-33-2048"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, None, true, "predefined-1-1024"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, None, true, "predefined-3-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, None, true, "predefined-1-1024"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), None, None, true, "predefined-4-1024"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), None, None, true, "predefined-16-14336"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), None, None, true, "predefined-1-13977"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), None, None, true, "predefined-1-1520"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), None, None, true, "predefined-1-1024"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, None, true, "predefined-33-2048"),
 
       // Same tests but with cascade lake (n2)
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionCascadeLake, false, "n2-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionCascadeLake, false, "n2-custom-4-4096"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionCascadeLake, false, "n2-custom-16-16384"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionCascadeLake, false, "n2-custom-36-36864"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionCascadeLake, None, false, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionCascadeLake, None, false, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionCascadeLake, None, false, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, None, false, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionCascadeLake, None, false, "n2-custom-36-36864"),
 
       // Same tests, but with ice lake. Should produce same results as cascade lake since they're both n2.
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionIceLake, false, "n2-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionIceLake, false, "n2-custom-4-4096"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionIceLake, false, "n2-custom-16-16384"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionIceLake, false, "n2-custom-36-36864"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionIceLake, None, false, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionIceLake, None, false, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionIceLake, None, false, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, None, false, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, None, false, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionIceLake, None, false, "n2-custom-36-36864"),
 
       // Same tests but with AMD Rome (n2d) #cpu > 16 are in increments of 16
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2dOption, false, "n2d-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2dOption, false, "n2d-custom-4-2048"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2dOption, false, "n2d-custom-16-14336"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1536"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2dOption, false, "n2d-custom-48-24576"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](81), n2dOption, false, "n2d-custom-96-49152"),
-      (MemorySize(256, MemoryUnit.GB), refineMV[Positive](128), n2dOption, false, "n2d-custom-96-262144")
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2dOption, None, false, "n2d-custom-2-1024"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2dOption, None, false, "n2d-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2dOption, None, false, "n2d-custom-2-1024"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2dOption, None, false, "n2d-custom-4-2048"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2dOption, None, false, "n2d-custom-16-14336"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2dOption, None, false, "n2d-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2dOption, None, false, "n2d-custom-2-1536"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2dOption, None, false, "n2d-custom-2-1024"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2dOption, None, false, "n2d-custom-48-24576"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](81), n2dOption, None, false, "n2d-custom-96-49152"),
+      (MemorySize(256, MemoryUnit.GB), refineMV[Positive](128), n2dOption, None, false, "n2d-custom-96-262144"),
+
+      // Test Standard Machine types
+      // General-purpose machine family
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("n1-standard-2"), false, "n1-standard-2"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("n1-highmem-2"), false, "n1-highmem-2"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("n1-highcpu-4"), false, "n1-highcpu-4"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("f1-micro"), false, "f1-micro"),
+
+      // Accelerator-optimized machine family
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("a2-highgpu-1g"), false, "a2-highgpu-1g"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("a3-megagpu-8g"), false, "a3-megagpu-8g"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("g2-standard-4"), false, "g2-standard-4"),
+
+      // Other machine families
+      // Storage-optimized
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("z3-highmem-88"), false, "z3-highmem-88"),
+      // Compute-optimized
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("h3-standard-88"), false, "h3-standard-88"),
+      // Memory-optimized
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("m3-ultramem-128"), false, "m3-ultramem-128"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("a2-highgpu-1g"), false, "a2-highgpu-1g"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("a2-highgpu-1g"), false, "a2-highgpu-1g"),
+
+      // Standard machine type overrides legacy selection
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("a2-highgpu-1g"), true, "a2-highgpu-1g"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, Option("a2-highgpu-1g"), false, "a2-highgpu-1g")
     )
 
-    forAll(validTypes) { (memory, cpu, cpuPlatformOption, googleLegacyMachineSelection, expected) =>
+    forAll(validTypes) { (memory, cpu, cpuPlatformOption, standardMachineTypeOption, googleLegacyMachineSelection, expected) =>
       GcpBatchMachineConstraints.machineType(
         memory = memory,
         cpu = cpu,
         cpuPlatformOption = cpuPlatformOption,
+        standardMachineTypeOption = standardMachineTypeOption,
         googleLegacyMachineSelection = googleLegacyMachineSelection,
         jobLogger = mock[JobLogger]
       ) shouldBe expected

--- a/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
+++ b/supportedBackends/google/batch/src/test/scala/cromwell/backend/google/batch/util/GcpBatchMachineConstraintsSpec.scala
@@ -1,23 +1,26 @@
 package cromwell.backend.google.batch.util
 
 import common.assertion.CromwellTimeoutSpec
+import common.mock.MockSugar.mock
 import cromwell.backend.google.batch.models.GcpBatchRuntimeAttributes
+import cromwell.core.logging.JobLogger
 import eu.timepit.refined.numeric.Positive
 import eu.timepit.refined.refineMV
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.prop.TableDrivenPropertyChecks._
 import org.scalatest.prop.Tables.Table
-import org.slf4j.helpers.NOPLogger
 import wdl4s.parser.MemoryUnit
 import wom.format.MemorySize
 
 class GcpBatchMachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpec with Matchers {
   behavior of "MachineConstraints"
 
-  private val n2Option = Option(GcpBatchRuntimeAttributes.CpuPlatformIntelCascadeLakeValue)
+  private val n2OptionCascadeLake = Option(GcpBatchRuntimeAttributes.CpuPlatformIntelCascadeLakeValue)
 
   private val n2dOption = Option(GcpBatchRuntimeAttributes.CpuPlatformAMDRomeValue)
+
+  private val n2OptionIceLake = Option(GcpBatchRuntimeAttributes.CpuPlatformIntelIceLakeValue)
 
   it should "generate valid machine types" in {
     val validTypes = Table(
@@ -41,7 +44,6 @@ class GcpBatchMachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpe
 
       // Same tests as above but with legacy machine type selection (cpu and memory as specified. No 'custom machine
       // requirement' adjustments are expected this time, except float->int)
-
       (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), None, true, "predefined-1-1024"),
       (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), None, true, "predefined-3-4096"),
       (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), None, true, "predefined-1-1024"),
@@ -53,15 +55,26 @@ class GcpBatchMachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpe
       (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), None, true, "predefined-33-2048"),
 
       // Same tests but with cascade lake (n2)
-      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2Option, false, "n2-custom-4-4096"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2Option, false, "n2-custom-4-4096"),
-      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2Option, false, "n2-custom-16-16384"),
-      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2Option, false, "n2-custom-2-14080"),
-      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2Option, false, "n2-custom-2-2048"),
-      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2Option, false, "n2-custom-36-36864"),
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionCascadeLake, false, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionCascadeLake, false, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionCascadeLake, false, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionCascadeLake, false, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionCascadeLake, false, "n2-custom-36-36864"),
+
+      // Same tests, but with ice lake. Should produce same results as cascade lake since they're both n2.
+      (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(4, MemoryUnit.GB), refineMV[Positive](3), n2OptionIceLake, false, "n2-custom-4-4096"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(1, MemoryUnit.GB), refineMV[Positive](4), n2OptionIceLake, false, "n2-custom-4-4096"),
+      (MemorySize(14, MemoryUnit.GB), refineMV[Positive](16), n2OptionIceLake, false, "n2-custom-16-16384"),
+      (MemorySize(13.65, MemoryUnit.GB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-14080"),
+      (MemorySize(1520.96, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(1024.0, MemoryUnit.MB), refineMV[Positive](1), n2OptionIceLake, false, "n2-custom-2-2048"),
+      (MemorySize(2, MemoryUnit.GB), refineMV[Positive](33), n2OptionIceLake, false, "n2-custom-36-36864"),
 
       // Same tests but with AMD Rome (n2d) #cpu > 16 are in increments of 16
       (MemorySize(1024, MemoryUnit.MB), refineMV[Positive](1), n2dOption, false, "n2d-custom-2-1024"),
@@ -83,7 +96,7 @@ class GcpBatchMachineConstraintsSpec extends AnyFlatSpec with CromwellTimeoutSpe
         cpu = cpu,
         cpuPlatformOption = cpuPlatformOption,
         googleLegacyMachineSelection = googleLegacyMachineSelection,
-        jobLogger = NOPLogger.NOP_LOGGER
+        jobLogger = mock[JobLogger]
       ) shouldBe expected
     }
   }


### PR DESCRIPTION
## Context

This change rebases https://github.com/broadinstitute/cromwell/pull/7545 as well as https://github.com/broadinstitute/cromwell/pull/7518 on top of the deepgenomics/dg-ci branch. The goal is to port only the functionality necessary to support arbitrary machine types in wdl workflows into our fork of the cromwell repository.

## Changes included

* https://github.com/broadinstitute/cromwell/pull/7518 starts passing machineType as a separate parameter when creating an instance policy to be used when calling GCP Batch.
* https://github.com/broadinstitute/cromwell/pull/7545 Creates a new standardMachineType runtime attribute in wdl workflows that allows us to configure such workflows to run on any predefined machine type on GCP.

## Testing

1. Ran unit and integration tests
```
# Start sbt console
sbt
# Only relevant tests
testOnly cromwell.backend.google.batch.util.GcpBatchMachineConstraintsSpec
# All tests
test
```

2. Deployed and ran a wdl workflow to validate the change

```
version 1.0

task nvidia_smi {
    input {
        String docker_version
    }

    command <<<
        nvidia-smi

        touch .done
        echo "Finished at $(date)"
    >>>

    runtime {
        docker: <internal image>
        disks: "local-disk 50 SSD"
        memory: "32G"
        preemptible: 0
        gpuCount: 1
        gpuType: "nvidia-tesla-a100"
        standardMachineType: "a2-highgpu-1g"
    }

    output {
        File done = ".done"
    }
}

workflow nvidia_smi_wf {
    input {
        String docker_version
    }
    
    call nvidia_smi  as nvidia_smi_call {
        input:
            docker_version = docker_version
    }

    output {
        File done = ".done"
    }
}
```

3. Verified the machine type on GCP batch as A2 and the output of nvidia-smi showing the requested A100 accelerator.