### PR TITLE
chore: change origin to dg

### DIFF
--- a/.github/set_up_cromwell_action/action.yml
+++ b/.github/set_up_cromwell_action/action.yml
@@ -36,7 +36,7 @@ runs:
       - name: Clone Cromwell
         uses: actions/checkout@v3
         with:
-          repository: broadinstitute/cromwell
+          repository: deepgenomics/cromwell
           token: ${{ inputs.cromwell_repo_token }}
 
       #Install Java to this VM. This Java version and distribution is compatible with Cromwell.

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Clone Cromwell
       uses: actions/checkout@v4
       with:
-        repository: broadinstitute/cromwell
+        repository: deepgenomics/cromwell
         token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
         path: cromwell
     - id: get-jira-id

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -32,17 +32,17 @@ name: Consumer contract tests
 on:
   pull_request:
     branches:
-      - develop
+      - dg-ci
     paths-ignore:
       - 'README.md'
   push:
     branches:
-      - develop
+      - dg-ci
     paths-ignore:
       - 'README.md'
   merge_group:
     branches:
-      - develop
+      - dg-ci
 
 env:
   PUBLISH_CONTRACTS_RUN_NAME: 'publish-contracts-${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Clone Cromwell
         uses: actions/checkout@v2
         with:
-          repository: broadinstitute/cromwell
+          repository: deepgenomics/cromwell
           token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
           path: cromwell
       - uses: actions/setup-java@v4

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -20,7 +20,7 @@ concurrency:
   # Don't run this workflow concurrently on the same branch
   group: ${{ github.workflow }}-${{ github.ref }}
   # For PRs, don't wait for completion of existing runs, cancel them instead
-  cancel-in-progress: ${{ github.ref != 'develop' }}
+  cancel-in-progress: ${{ github.ref != 'dg-ci' }}
 
 jobs:
   integration-tests:


### PR DESCRIPTION
Change origin to deepgenomics so that github actions that checkout
the default branch don't fail when we skip tests that require an Azure token.