### PR TITLE
chore: BROADBOT_GITHUB_TOKEN => GITHUB_TOKEN

### DIFF
--- a/.github/workflows/azure_e2e_run_workflow.yml
+++ b/.github/workflows/azure_e2e_run_workflow.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 env:
-  BROADBOT_TOKEN: '${{ secrets.BROADBOT_GITHUB_TOKEN }}' # github token for access to kick off a job in the private repo
+  BROADBOT_TOKEN: '${{ secrets.GITHUB_TOKEN }}' # github token for access to kick off a job in the private repo
   RUN_NAME_SUFFIX: '${{ github.event.repository.name }}-${{ github.run_id }}-${{ github.run_attempt }}'
 
 jobs:

--- a/.github/workflows/chart_update_on_merge.yml
+++ b/.github/workflows/chart_update_on_merge.yml
@@ -15,7 +15,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: deepgenomics/cromwell
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        token: ${{ secrets.GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
         path: cromwell
     - id: get-jira-id
       # We're cloning multiple repos, so Cromwell and its actions are at `./cromwell/` instead of `./`
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v2
       with:
         repository: broadinstitute/cromwhelm
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        token: ${{ secrets.GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
         path: cromwhelm
     - name: Find Cromwell short SHA
       run: |
@@ -62,20 +62,20 @@ jobs:
     - name: Deploy to dev and board release train (Cromwell)
       uses: broadinstitute/repository-dispatch@master
       with:
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         repository: broadinstitute/terra-helmfile
         event-type: update-service
         client-payload: '{"service": "cromwell", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
     - name: Deploy to dev and board release train (CromIAM)
       uses: broadinstitute/repository-dispatch@master
       with:
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         repository: broadinstitute/terra-helmfile
         event-type: update-service
         client-payload: '{"service": "cromiam", "version": "${{ env.CROMWELL_VERSION }}", "dev_only": false}'
     - name: Edit & push cromwhelm chart
       env:
-        BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -e
         cd cromwhelm
@@ -87,14 +87,14 @@ jobs:
         git config --global user.name "broadbot"
         git config --global user.email "broadbot@broadinstitute.org"
         git commit -am "${{ steps.get-jira-id.outputs.jira-id }}: Auto update to Cromwell $CROMWELL_VERSION"
-        git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
+        git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/cromwhelm.git main
         cd -
 
     - name: Clone terra-helmfile
       uses: actions/checkout@v3
       with:
         repository: broadinstitute/terra-helmfile
-        token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+        token: ${{ secrets.GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
         path: terra-helmfile
 
     - name: Update workflows-app in terra-helmfile
@@ -114,8 +114,8 @@ jobs:
 
     - name: Make PR in terra-helmfile
       env:
-        BROADBOT_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
-        GH_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        BROADBOT_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         set -e
         JIRA_ID=${{ steps.get-jira-id.outputs.jira-id }}

--- a/.github/workflows/combine_scalasteward_prs.yml
+++ b/.github/workflows/combine_scalasteward_prs.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Merge scala-steward PRs
         id: msp
         run: |
-          export GITHUB_TOKEN=${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          export GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }}
           PR_LIMIT=${{ github.event.inputs.prLimit }}
           PR_GROUP_SIZE=${{ github.event.inputs.prGroupSize }}
           echo "BASH_VERSION=${BASH_VERSION}"

--- a/.github/workflows/consumer_contract_tests.yml
+++ b/.github/workflows/consumer_contract_tests.yml
@@ -154,7 +154,7 @@ jobs:
           workflow: .github/workflows/publish-contracts.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # github token for access to kick off a job in the private repo
+          token: ${{ secrets.GITHUB_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{
             "run-name": "${{ env.PUBLISH_CONTRACTS_RUN_NAME }}",
             "pact-b64": "${{ needs.cromwell-contract-tests.outputs.pact-b64-drshub }}",
@@ -170,7 +170,7 @@ jobs:
           workflow: .github/workflows/publish-contracts.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # github token for access to kick off a job in the private repo
+          token: ${{ secrets.GITHUB_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{
             "run-name": "${{ env.PUBLISH_CONTRACTS_RUN_NAME }}",
             "pact-b64": "${{ needs.cromwell-contract-tests.outputs.pact-b64-cbas }}",
@@ -192,7 +192,7 @@ jobs:
           workflow: .github/workflows/can-i-deploy.yaml
           repo: broadinstitute/terra-github-workflows
           ref: refs/heads/main
-          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # github token for access to kick off a job in the private repo
+          token: ${{ secrets.GITHUB_TOKEN }} # github token for access to kick off a job in the private repo
           inputs: '{
             "run-name": "${{ env.CAN_I_DEPLOY_RUN_NAME }}",
             "pacticipant": "cromwell",

--- a/.github/workflows/cromwell_unit_tests.yml
+++ b/.github/workflows/cromwell_unit_tests.yml
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3 # checkout the cromwell repo
     - uses: ./.github/set_up_cromwell_action #Exectute this reusable github action. It will set up java/sbt/git-secrets/cromwell.
       with:
-        cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        cromwell_repo_token: ${{ secrets.GITHUB_TOKEN }}
   
     #Invoke SBT to run all unit tests for Cromwell. 
     - name: Run tests

--- a/.github/workflows/docker_build_test.yml
+++ b/.github/workflows/docker_build_test.yml
@@ -23,7 +23,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: deepgenomics/cromwell
-          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
           path: cromwell
       - uses: actions/setup-java@v4
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -101,7 +101,7 @@ jobs:
         ref: ${{ inputs.target-branch }}
     - uses: ./.github/set_up_cromwell_action #This github action will set up git-secrets, caching, java, and sbt.
       with:
-        cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+        cromwell_repo_token: ${{ secrets.GITHUB_TOKEN }}
     # Activate SSH and idle for 30 minutes
 #    - name: Setup tmate session
 #      uses: mxschmitt/action-tmate@v3

--- a/.github/workflows/make_publish_prs.yml
+++ b/.github/workflows/make_publish_prs.yml
@@ -22,12 +22,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: broadinstitute/firecloud-develop
-          token: ${{ secrets.BROADBOT_GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
+          token: ${{ secrets.GITHUB_TOKEN }} # Has to be set at checkout AND later when pushing to work
           path: firecloud-develop
       - name: Update & push to firecloud-develop
         id: update-and-push
         env:
-          BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd firecloud-develop
           JIRA_TICKET=${{ github.event.inputs.jira_ticket }}
@@ -49,12 +49,12 @@ jobs:
           git config --global user.name "broadbot"
           git config --global user.email "broadbot@broadinstitute.org"
           git commit -m "Updating Cromwell version to ${NEW_CROMWELL_V}"
-          git push https://broadbot:$BROADBOT_GITHUB_TOKEN@github.com/broadinstitute/firecloud-develop.git ${NEW_BRANCH_NAME}
+          git push https://broadbot:$GITHUB_TOKEN@github.com/broadinstitute/firecloud-develop.git ${NEW_BRANCH_NAME}
           echo "NEW_BRANCH_NAME=${NEW_BRANCH_NAME}" >> $GITHUB_OUTPUT
       - name: Create firecloud-develop PR
         uses: actions/github-script@v6
         with:
-          github-token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
             const result = await github.rest.pulls.create({
               title: '${{ github.event.inputs.jira_ticket }}: Update Cromwell version to ${{ github.event.inputs.new_cromwell_version }}',

--- a/.github/workflows/scalafmt-check.yml
+++ b/.github/workflows/scalafmt-check.yml
@@ -24,7 +24,7 @@ jobs:
           ref: ${{ inputs.target-branch }}
       - uses: ./.github/set_up_cromwell_action
         with:
-          cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          cromwell_repo_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run ScalaFmt
         run: |
           sbt scalafmtCheckAll

--- a/.github/workflows/scalafmt-fix.yml
+++ b/.github/workflows/scalafmt-fix.yml
@@ -49,11 +49,11 @@ jobs:
          ref: ${{ inputs.target-branch }}
       - uses: ./.github/set_up_cromwell_action
         with:
-          cromwell_repo_token: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          cromwell_repo_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Run ScalaFmt Fixup
         if: steps.check-comment.outputs.comment-triggered == 'true' || github.event_name == 'workflow_dispatch'
         env:
-          BROADBOT_GITHUB_TOKEN: ${{ secrets.BROADBOT_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           sbt scalafmtAll
           git config --global user.email "broadbot@broadinstitute.org"


### PR DESCRIPTION
Similar to #4, this must be merged first (in a failing state)