### PR TITLE
feat: allow monitoring image to collect gpu metrics

### DIFF
--- a/.github/workflows/scalafmt-fix.yml
+++ b/.github/workflows/scalafmt-fix.yml
@@ -50,7 +50,6 @@ jobs:
       - uses: ./.github/set_up_cromwell_action
         with:
           cromwell_repo_token: ${{ secrets.GITHUB_TOKEN }}
-        secrets: inherit
       - name: Run ScalaFmt Fixup
         if: steps.check-comment.outputs.comment-triggered == 'true' || github.event_name == 'workflow_dispatch'
         env:

--- a/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
+++ b/supportedBackends/google/batch/src/main/scala/cromwell/backend/google/batch/api/GcpBatchRequestFactoryImpl.scala
@@ -89,15 +89,20 @@ class GcpBatchRequestFactoryImpl()(implicit gcsTransferConfiguration: GcsTransfe
       .setMinCpuPlatform(cpuPlatform)
       .buildPartial()
 
-    // add GPUs if GPU count is greater than 1
-    if (gpuAccelerators.getCount >= 1) {
-      val instancePolicyGpu = instancePolicy.toBuilder
-      instancePolicyGpu.addAccelerators(gpuAccelerators).build
-      instancePolicyGpu
-    } else {
-      instancePolicy.toBuilder
+    if (gpuAccelerators.getCount < 1) {
+      return instancePolicy.toBuilder
     }
 
+    // add GPUs if GPU count is greater than 1
+    val instancePolicyGpu = instancePolicy.toBuilder
+    val disk = if (instancePolicyGpu.hasBootDisk) {
+      instancePolicyGpu.getBootDisk.toBuilder
+    } else {
+      Disk.newBuilder
+    }
+    disk.setImage("batch-debian")
+    instancePolicyGpu.addAccelerators(gpuAccelerators).setBootDisk(disk).build
+    instancePolicyGpu
   }
 
   private def createNetworkPolicy(networkInterface: NetworkInterface): NetworkPolicy =


### PR DESCRIPTION
in order to support using pynvml without blowing up the size of the monitoring docker image, tasks need to run on the non-default batch-debian vm image. This makes google batch set up the nvidia drivers on the vm and mount them to the container instead of relying on the drivers being installed on the monitor image.

An added benefit is reduced docker image sizes for all tasks that require a gpu.